### PR TITLE
fix(config): valid function check for react-native

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,15 @@
 module.exports = {
   name: 'asyncstorage',
   valid: function () {
-    return typeof React !== 'undefined';
+    if (typeof React === 'undefined') {
+      var React;
+      try {
+        React = require('react-native');
+      } catch(e) {
+        React = {};
+      }
+    }
+    return React.hasOwnProperty('AsyncStorage');
   },
   use_prefix: true
 };


### PR DESCRIPTION
`React` is not a global in react-native, so we have to require it, to see if it is there. While we are doing this, we might as well check for AsyncStorage. I think this is a sane validation.

@nolanlawson Please review and merge if OK.
