### PR TITLE
fix(package): use updated asyncstorage-down

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mkdirp": "^0.5.0"
   },
   "dependencies": {
-    "asyncstorage-down": "0.0.1",
+    "asyncstorage-down": "0.0.2",
     "pouchdb": "pouchdb/pouchdb#for-react-native"
   }
 }


### PR DESCRIPTION
If asyncstorage-down doesn't declare the latest react-native as dependency, that leads to an Error in the console. This is currently a show stopper in my example app.

However, we should wait until there is a proper npm release. Currently [waiting for that](https://github.com/tradle/asyncstorage-down/pull/1#issuecomment-98840567). If so, **I will force push** this branch.
