### PR TITLE
just use pouchdb 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "asyncstorage-down": "0.0.2",
-    "pouchdb": "pouchdb/pouchdb#for-react-native"
+    "pouchdb": "^3.5.0"
   }
 }


### PR DESCRIPTION
This release should contain all the fixes we need for
react-native. At least until we figure out what
else is failing.
